### PR TITLE
apply yawf-float to weibo ttarticle

### DIFF
--- a/Yet_Another_Weibo_Filter.user.js
+++ b/Yet_Another_Weibo_Filter.user.js
@@ -8797,10 +8797,13 @@ filter.items.tool.fixed.hide_nav_bar = filter.item({
   'ainit': function () {
     var attr = 'yawf-float';
     var updateNavFloat = function () {
-      var nav = document.querySelector('.WB_global_nav'); if (!nav) return;
-      var y = window.scrollY, f = nav.hasAttribute(attr), r = 42;
-      if (y < r && f) nav.removeAttribute(attr);
-      if (y >= r && !f) nav.setAttribute(attr, '');
+      var navs = document.querySelectorAll('.WB_global_nav');
+      if (!navs.length) return;
+      for (let nav of navs) {
+        var y = window.scrollY, f = nav.hasAttribute(attr), r = 42;
+        if (y < r && f) nav.removeAttribute(attr);
+        if (y >= r && !f) nav.setAttribute(attr, '');
+      }
     };
     document.addEventListener('scroll', updateNavFloat);
     updateNavFloat();


### PR DESCRIPTION
微博文章（https://weibo.com/ttarticle/p/* ），例如 https://weibo.com/ttarticle/p/show?id=2309404322187992547002
与微博主页结构不同，有两个```.WB_global_nav```的标签，
![image](https://user-images.githubusercontent.com/12387091/50533713-ecdf3200-0b6a-11e9-99f3-a8c53c43f8ba.png)
用```document.querySelector()```不能有效的自动隐藏导航栏，故采用```document.querySelectorAll()```代替