### PR TITLE
102: 修改 防止图片批量时下载失败

### DIFF
--- a/Yet_Another_Weibo_Filter.user.js
+++ b/Yet_Another_Weibo_Filter.user.js
@@ -4294,6 +4294,9 @@ html { background: #f9f9fa; }
           method: 'GET',
           url: url,
           responseType: 'arraybuffer',
+          headers: {
+            "Referer": "https://weibo.com/"
+          },
           onload: function (resp) {
             const mtime = (resp.responseHeaders.match(/^Last-Modified: (.*)$/mi) || [])[1];
             resolve({


### PR DESCRIPTION
从昨天(2022年6月21日)开始似乎加入了反盗链机制，批量下载大概率失败