### PR TITLE
feat(redirect): 自动重定向未在微博备案的外部站点链接

### DIFF
--- a/Yet_Another_Weibo_Filter.user.js
+++ b/Yet_Another_Weibo_Filter.user.js
@@ -18,6 +18,7 @@
 // @include           *://weibo.com/*
 // @include           *://*.weibo.com/*
 // @include           *://t.cn/*
+// @include           *://weibo.cn/*
 // @exclude           *://weibo.com/a/bind/*
 // @exclude           *://account.weibo.com/*
 // @exclude           *://kefu.weibo.com/*
@@ -2843,6 +2844,15 @@ html { background: #f9f9fa; }
 ; (function () {
   if (location.host !== 't.cn') return;
   throw new Error('YAWF | t.cn page found, skip following executions');
+}());
+
+; (function () {
+  if (location.host !== 'weibo.cn' || location.pathname !== '/sinaurl') return;
+  const urlParams = new URLSearchParams(location.search);
+  const targetUrl = urlParams.get('u');
+  if (targetUrl) {
+    location.replace(decodeURIComponent(targetUrl));
+  }
 }());
 //#endregion
 //#region @require yaofang://content/init/page.js


### PR DESCRIPTION
例如网页链接到 Twitter，点击后会跳转到中转页面如 `https://weibo.cn/sinaurl?u=https%3A%2F%2Fx.com%2Fmimmi_sak%2Fstatus%2F1961679941323673613%3Ft%3DFe0dBgicaYpabOeN6riJsw%26s%3D19`。

<img width="1359" height="1053" alt="外部站点中转页面" src="https://github.com/user-attachments/assets/f1ba25ea-5007-4e41-a0af-c350746e03f8" />

此时需要手动复制链接地址再访问。对于 Tampermonkey 使用者来说这大抵是“多此一举”的步骤，因此该 PR 实现了自动重定向到对应的外部站点。