### PR TITLE
添加「使用最新微博代替首页」功能

### DIFF
--- a/yyawf.user.js
+++ b/yyawf.user.js
@@ -358,6 +358,58 @@ const payload = (Array(35).fill('\n').join('') + 'void(' + function (config, mes
     isDebug = yawfConfig['about::debug'];
   });
 
+  //#region 首页路由修正
+  appReady.then(app => {
+    const router = app.config.globalProperties.$router;
+    if (!router) return;
+    const uid = $CONFIG.user.idstr;
+    const gid = '11000' + uid;
+    const targetPath = '/mygroups?gid=' + gid;
+
+    const isHomeRoute = route => {
+      if (!route) return false;
+      if (route.name === 'home') return true;
+      const path = route.path || route.fullPath || '';
+      return path === '/' || path === '/home' || path.startsWith('/home?') || path.startsWith('/home/');
+    };
+
+    if (typeof router.__yawf_fix_home_guard__ === 'function') {
+      router.__yawf_fix_home_guard__();
+    }
+    router.__yawf_fix_home_guard__ = router.beforeEach(to => {
+      if (!getConfigBoolean('home::newest')) return;
+      if (isHomeRoute(to)) return targetPath;
+    });
+
+    const currentRoute = router.currentRoute.value;
+    if (getConfigBoolean('home::newest') && isHomeRoute(currentRoute)) {
+      router.replace(targetPath).catch(() => {});
+    }
+
+    // 拦截 $Bus 事件
+    const bus = app.config.globalProperties.$Bus;
+    if (bus) {
+      // 拦截 reload 事件，将 home 重定向到最新微博
+      const originalEmit = bus.$emit;
+      bus.$emit = function (eventName, ...args) {
+        if (getConfigBoolean('home::newest')) {
+          if (eventName === 'reload' && args[0] === 'home') {
+            return originalEmit.call(this, 'handleHomeNav', { gid, title: '最新微博', api: '/ajax/feed/friendstimeline', yawf_Trigger: true }, 1, 'left');
+          }
+          if (eventName === 'handleHomeNav') {
+            const data = args[0];
+            const dataGid = String(data?.gid ?? '');
+            if (dataGid.startsWith('10001') && !data.yawf_Trigger) {
+              return originalEmit.call(this, 'handleHomeNav', { gid, title: '最新微博', api: '/ajax/feed/friendstimeline', yawf_Trigger: true }, 1, 'left');
+            }
+          }
+        }
+        return originalEmit.apply(this, arguments);
+      };
+    }
+  });
+  //#endregion
+
   appReady.then(app => {
     log('Vue 加载完成');
     app.mixin({
@@ -1399,6 +1451,12 @@ const CONFIG_TEMPLATE = /* html */`
         <div><yawf-users key="filter::authors" /></div>
       </yawf-rule>
       <p>此处的作者会被应用于微博的作者、转发原作者、共著作者等用户。</p>
+    </yawf-group>
+    <yawf-group name="首页">
+      <yawf-rule id="home::newest">
+        <yawf-checkbox key="home::newest">使用最新微博代替首页（首页微博时间顺序排列）</yawf-checkbox>
+      </yawf-rule>
+      <p>启用后，点击左上角微博图标或「全部关注」时也会跳转到最新微博页面。</p>
     </yawf-group>
   </yawf-tab>
   <yawf-tab name="界面清理">

--- a/yyawf.user.js
+++ b/yyawf.user.js
@@ -386,26 +386,134 @@ const payload = (Array(35).fill('\n').join('') + 'void(' + function (config, mes
       router.replace(targetPath).catch(() => {});
     }
 
-    // 拦截 $Bus 事件
+    const isEnabled = () => getConfigBoolean('home::newest');
+
+    // 站内有一条“回首页”的事件链路：点击左上角微博图标/首页入口 -> $Bus.$emit('reload','home')
+    // 但在“最新微博”页这会打 /ajax/feed/unreadfriendstimeline?list_id=10001...，把信息流刷成非时间序。
+    // 这里拦截点击，并改为复用站内正常的“切到最新微博”导航链路（handleHomeNav）。
+    if (typeof router.__yawf_fix_home_click_guard__ === 'function') {
+      router.__yawf_fix_home_click_guard__();
+    }
+    const isAtTarget = () => {
+      try {
+        const url = new URL(location.href);
+        return url.pathname === '/mygroups' && url.searchParams.get('gid') === String(gid);
+      } catch {
+        return false;
+      }
+    };
+
+    const findGroupInAllGroups = (groups, wantGid) => {
+      // allGroups response shape: { groups: [ { group: [ ... ] }, ... ] }
+      const root = Array.isArray(groups) ? groups : [];
+      for (const item of root) {
+        const list = Array.isArray(item?.group) ? item.group : null;
+        if (!list) continue;
+        const index = list.findIndex(g => String(g?.gid ?? '') === String(wantGid));
+        if (index !== -1) return { group: list[index], index };
+      }
+      return null;
+    };
+    const buildNewestPayload = g => {
+      // allGroups payload may omit fields that web-weibo expects when navigating.
+      const apipath = String(g?.apipath ?? '');
+      const api = typeof g?.api === 'string' && g.api ? g.api :
+        apipath === 'statuses/friends/timeline' ? '/ajax/feed/friendstimeline' : null;
+      return {
+        ...g,
+        api: api ?? g?.api,
+        name: g?.name ?? g?.title ?? '最新微博',
+        title: g?.title ?? g?.name ?? '最新微博',
+        loadEmptyPic: g?.loadEmptyPic ?? false,
+        yawf_Trigger: true,
+      };
+    };
+
+    let newestGroupPromise = null;
+    const getNewestGroup = async () => {
+      if (newestGroupPromise) return newestGroupPromise;
+      newestGroupPromise = fetch('/ajax/feed/allGroups', { credentials: 'include' })
+        .then(r => r.json())
+        .then(({ groups } = {}) => findGroupInAllGroups(groups, gid))
+        .catch(() => {
+          newestGroupPromise = null;
+          return null;
+        });
+      return newestGroupPromise;
+    };
+    const routeToNewest = async ({ force = false } = {}) => {
+      if (!force && isAtTarget()) return;
+      router.replace(targetPath).catch(() => {});
+      const bus = app.config.globalProperties.$Bus;
+      if (bus && typeof bus.$emit === 'function') {
+        const groupInfo = await getNewestGroup();
+        if (groupInfo?.group) {
+          bus.$emit('handleHomeNav', buildNewestPayload(groupInfo.group), groupInfo.index, 'left');
+          return;
+        }
+        // fallback: 拿不到完整 group 配置时，尽力触发一次导航（不保证所有站内逻辑都能跟上）
+        bus.$emit('handleHomeNav', { gid, title: '最新微博', yawf_Trigger: true }, 1, 'left');
+        return;
+      }
+    };
+    const normalizeText = s => String(s ?? '').replace(/[\u200b\r\n]+/g, '').trim();
+    const isHomeEntryAnchor = a => {
+      if (!a) return false;
+      const text = normalizeText(a.textContent);
+      const href = a.getAttribute?.('href');
+      // Left sidebar "全部关注" link (href="/") routes to home.
+      if (text === '全部关注' && href === '/') return true;
+
+      // Top nav logo / home tabs.
+      if (!a.closest?.('[__yawf_component_weibo-top-nav-base__]')) return false;
+      if (a.matches?.('a.__yawf_weibo-top-nav-base_logoWrap')) return true;
+      if (text.startsWith('首页')) return true;
+      return href === '/';
+    };
+    const clickGuard = e => {
+      if (!isEnabled()) return;
+      if (e.defaultPrevented) return;
+      if ('button' in e && e.button !== 0) return;
+      if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+
+      const a = e.target?.closest?.('a');
+      if (!isHomeEntryAnchor(a)) return;
+
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      e.stopPropagation();
+
+      routeToNewest({ force: true }).catch(() => {});
+    };
+    document.addEventListener('click', clickGuard, true);
+    router.__yawf_fix_home_click_guard__ = () => {
+      document.removeEventListener('click', clickGuard, true);
+    };
+
+    // $router 的改动不一定会驱动首页内容切换（站内很多是通过 $Bus 驱动的）。
+    // 为避免侵入式 override $emit，这里采用类似旧版 YAWF 的方式：监听关键事件并补发导航事件。
     const bus = app.config.globalProperties.$Bus;
     if (bus) {
-      // 拦截 reload 事件，将 home 重定向到最新微博
-      const originalEmit = bus.$emit;
-      bus.$emit = function (eventName, ...args) {
-        if (getConfigBoolean('home::newest')) {
-          if (eventName === 'reload' && args[0] === 'home') {
-            return originalEmit.call(this, 'handleHomeNav', { gid, title: '最新微博', api: '/ajax/feed/friendstimeline', yawf_Trigger: true }, 1, 'left');
+      const on = typeof bus.$on === 'function' ? bus.$on : (typeof bus.on === 'function' ? bus.on : null);
+      if (on) {
+        // 某些入口会通过事件总线“回首页”，但路由不变；这里兜底把它们导向“最新微博”。
+        on.call(bus, 'reload', function (...args) {
+          if (!isEnabled()) return;
+          if (args[0] !== 'home') return;
+          if (isAtTarget()) return;
+          routeToNewest().catch(() => {});
+        });
+
+        on.call(bus, 'handleHomeNav', function (data) {
+          if (!isEnabled()) return;
+          if (data?.yawf_Trigger) return;
+          const dataGid = String(data?.gid ?? '');
+          if (dataGid.startsWith('10001')) {
+            if (isAtTarget()) return;
+            routeToNewest().catch(() => {});
           }
-          if (eventName === 'handleHomeNav') {
-            const data = args[0];
-            const dataGid = String(data?.gid ?? '');
-            if (dataGid.startsWith('10001') && !data.yawf_Trigger) {
-              return originalEmit.call(this, 'handleHomeNav', { gid, title: '最新微博', api: '/ajax/feed/friendstimeline', yawf_Trigger: true }, 1, 'left');
-            }
-          }
-        }
-        return originalEmit.apply(this, arguments);
-      };
+        });
+      }
     }
   });
   //#endregion


### PR DESCRIPTION
    添加「使用最新微博代替首页」功能

    - 在药方设置→微博过滤中新增「首页」分组
    - 启用后首页自动跳转到最新微博页面（时间顺序排列）
    - 拦截左上角微博图标和「全部关注」点击事件
    - 新增 yawf-tip 提示图标组件
 
    基于以下测试：
    - 浏览器：Chrome Version 143.0.7499.169 (Official Build) (64-bit)
    - 浏览器扩展：TamperMonkey v5.4.1